### PR TITLE
Avoid error in R >= 4.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,8 @@ Imports:
   methods,
   grDevices
 RoxygenNote: 7.2.0
+Remotes:
+  bleutner/RStoolbox
 Suggests: 
   testthat,
   covr

--- a/R/internal.R
+++ b/R/internal.R
@@ -859,7 +859,7 @@ rbind.different <- function(x) {
   all_na <- sapply(x, function(element) {
     return(ifelse(inherits(element, LIST()), FALSE, is.na(element)))
   })
-  return(length(x) == 0 || is.null(x) || is.na(x) || all_null || all_na)
+  return(length(x) == 0 || is.null(x) || all(is.na(x)) || all(all_null) || all(all_na))
 }
 
 #' checks if a character can be integer


### PR DESCRIPTION
Using R 4.3.0 an error occurs due to the first user-visible change reported in the [R 4.3.0 changelog](https://cran.r-project.org/doc/manuals/r-release/NEWS.html); this PR fixes that.
Note that the new syntax should keep the original output value, but I have not performed any test on it.

Moreover, I edited the DESCRIPTION file in order to install RStoolbox from GitHub repo, since [it was removed from CRAN](https://cran.r-project.org/web/packages/RStoolbox/index.html) (maybe you could also consider to remove this dependence editing the code where `ggR()` and `ggRGB()` are used).

Thank you