### PR TITLE
fix error when removing duplicate columns

### DIFF
--- a/R/check_availability.R
+++ b/R/check_availability.R
@@ -66,7 +66,7 @@ check_availability <- function(records, verbose = TRUE){
       
       # if there is something, digg deeper
       if(!is.na(order_ids[1])){
-        browser()
+        
         # get item ids for each order
         item_ids <- lapply(order_ids, function(x){
           response <- content(.get(paste0(getOption("gSD.api")$espa, "/order/", x), getOption("gSD.usgs_user"), getOption("gSD.usgs_pass")))
@@ -77,7 +77,7 @@ check_availability <- function(records, verbose = TRUE){
         # extract order ids that match records and are still hot for download
         records[sub,]$gSD.order_id <- .sapply(records[sub,]$record_id, function(recid){
           match_item <- .sapply(item_ids, function(itid) recid %in% itid)
-          if(any(match_item)) order_ids[match_item] else NA
+          if(any(match_item)) order_ids[match_item][1] else NA
         })
         #records[sub,][records[sub,]$record_id %in% unlist(item_ids),]$gSD.order_id <- order_ids[unlist(item_ids) %in% records[sub,]$record_id]
         #records[sub,]$gSD.order_id <- order_ids[sapply(records[sub,]$record_id, function(x) which(x == item_ids)[1])]

--- a/R/check_availability.R
+++ b/R/check_availability.R
@@ -60,12 +60,13 @@ check_availability <- function(records, verbose = TRUE){
       
       # extract order ids of last 7 days
       order_ids <- gsub('\\["', "", gsub('"]', "", strsplit(xml_text(xml_children(order_ids)[[1]]), '\", \"')[[1]]))
-      order_dates <- lapply(order_ids, function(x) strptime(strsplit(x, "-")[[1]][3], format = "%m%d%Y"))
+      # get third to last string of split, thereby ignoring possible hyphens in account e-mail-adress
+      order_dates <- lapply(order_ids, function(x) strptime(strsplit(x, "-")[[1]][length(strsplit(x, "-")[[1]])-2], format = "%m%d%Y"))
       order_ids <- order_ids[sapply(order_dates, function(x) difftime(Sys.time(), x, units = "days")) <= 7]
       
       # if there is something, digg deeper
       if(!is.na(order_ids[1])){
-        
+        browser()
         # get item ids for each order
         item_ids <- lapply(order_ids, function(x){
           response <- content(.get(paste0(getOption("gSD.api")$espa, "/order/", x), getOption("gSD.usgs_user"), getOption("gSD.usgs_pass")))

--- a/R/internal.R
+++ b/R/internal.R
@@ -141,7 +141,10 @@
     records$stop_time <- as.POSIXct(strptime(records$stop_time, "%Y:%j:%T", tz = "UTC"))
     records$date_acquisition <- as.Date(records$start_time)
     records$start_date <- records$stop_date <- NULL
-    records[, which(colnames(records) == "cloudcov")[2]] <- NULL #remove duplicated column
+    # Find and remove Duplicated Columns
+    duplicated_columns <- duplicated(as.list(records))
+    records <- records[!duplicated_columns]
+    #records[, which(colnames(records) == "cloudcov")[2]] <- NULL #remove duplicated column
   }
   if(product_group == "modis"){
     records$start_time <- as.POSIXct(strptime(records$start_date, "%Y-%m-%d %T", tz = "UTC"))


### PR DESCRIPTION
Fix of error:
Searching records for product name 'landsat_tm_c2_l2'...
Recieving available product levels from USGS-EROS ESPA...
Error in [<-.data.frame(*tmp*, , which(colnames(records) == "cloudcov")[2], :
missing values are not allowed in subscripted assignments of data frames

See also discussion in https://github.com/16EAGLE/getSpatialData/issues/108